### PR TITLE
indentation support for clojure.test standard library

### DIFF
--- a/indent/clojure.vim
+++ b/indent/clojure.vim
@@ -32,6 +32,9 @@ setlocal lispwords+=ns,clojure.core/ns
 " Java Classes:
 setlocal lispwords+=gen-class,gen-interface
 
+" clojure.test package:
+setlocal lispwords+=deftest,deftest-,testing
+
 setlocal indentexpr=clojure#indent#get(v:lnum)
 
 setlocal noautoindent nosmartindent


### PR DESCRIPTION
leiningen generates these functions by default in `lein new {project name}`.
