### PR TITLE
Fix the issue with termguicolors

### DIFF
--- a/autoload/clojure/syntax.vim
+++ b/autoload/clojure/syntax.vim
@@ -24,7 +24,7 @@ endif
 
 function! s:colors()
   let base = get(g:clojure#syntax#paren_colors, &background, {})
-  if has('gui_running') && has_key(base, 'gui')
+  if (has('gui_running') || has('termguicolors') && &termguicolors) && has_key(base, 'gui')
     return {'colors': base.gui, 'type': 'gui'}
   elseif has_key(base, 'cterm' . &t_Co)
     return {'colors': base['cterm' . &t_Co], 'type': 'cterm'}

--- a/doc/ft-clojure.txt
+++ b/doc/ft-clojure.txt
@@ -42,7 +42,8 @@ g:clojure#syntax#paren_colors			*g:clojure#syntax#paren_colors*
 	the value of 'background'.
 	Each values are also dictionary.  Its key is a environment, value is a
 	list of colors.  The environment is followings.
-	"gui":		This is used when `has("gui_running")` is true.
+	"gui":		This is used when `has("gui_running")` is true or
+			|termguicolors| is set.
 	"term" . &t_Co:	This is used when `has("gui_running")` is false and
 			|t_Co| is matched.
 	"term":		Otherwise.


### PR DESCRIPTION
Problem: The parentheses are colourless when using on terminal with termguicolors set.

Solution: check if gui_running or &termguicolors.

This fix is trivial, so feel free to close this PR and commit your own fix instead if something is wrong.

---

`termguicolors` の設定されたターミナル上の vim では `gui_running` が 0 でも gui 系でハイライトしないと色がつかないので，その対応です．

Trivial な変更なので，なにか問題や気に食わない点があればレビューせずに単純にPRを閉じてご自分で commit してくださっても結構です．
